### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:sipeed-longan-nano]
-platform = gd32v
+platform = https://github.com/sipeed/platform-gd32v.git
 board = sipeed-longan-nano-lite
 framework = gd32vf103-sdk
 upload_protocol = dfu


### PR DESCRIPTION
The oringinal code: platform = gd32v couldn't find the board as sipeed-longan-nano-lite.
So change the platform as this URL: https://github.com/sipeed/platform-gd32v.git can solve the issue and let demo work.